### PR TITLE
add returning type for InjectionAwareInterface::setDI

### DIFF
--- a/plugin/src/Phalcon/Di/InjectionAwareInterface.php
+++ b/plugin/src/Phalcon/Di/InjectionAwareInterface.php
@@ -22,7 +22,7 @@ interface InjectionAwareInterface
      * @param DiInterface $container
      * @return void
      */
-    public function setDI(DiInterface $container);
+    public function setDI(DiInterface $container): void;
 
     /**
      * Returns the internal dependency injector


### PR DESCRIPTION
When updating Phalcon to version 4.1.2-r0, I encountered an error `must be compatible with Phalcon\Di\InjectionAwareInterface::setDI(Phalcon\Di\DiInterface $container): void`
it turned out that it was needs to specify the return type `void`